### PR TITLE
Fixes for travis-ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: cpp
+
 compiler:
   - gcc
-  - clang
+
 before_install:
+  # We need GCC 4.8 for the unit tests
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
-  - sudo apt-get install -yqq libevent-dev
+
+install:
+  - sudo apt-get install -yqq g++-4.8 libevent-dev
+  - export CXX="g++-4.8"
+
 script: mkdir build && cd build && cmake .. && make && ./test/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: cpp
 compiler:
   - gcc
   - clang
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -yqq libevent-dev
 script: mkdir build && cd build && cmake .. && make && ./test/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif (NOT CMAKE_BUILD_TYPE)
 include(ExternalProject)
 include(External_gtest)
 include(External_http-parser)
-include(External_libevent)
+include(External_LibEvent)
 
 # Use C++11 when building C++ code
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")


### PR DESCRIPTION
- install & use gcc 4.8
- install libevent-dev
